### PR TITLE
Add support for specifying subprotocol on handshake

### DIFF
--- a/src/main/scala/com/github/andyglow/websocket/WebsocketClient.scala
+++ b/src/main/scala/com/github/andyglow/websocket/WebsocketClient.scala
@@ -66,12 +66,12 @@ object WebsocketClient {
     subprotocol: Option[String] = None,
     maybeSslCtx: Option[SslContext] = None): WebsocketClient[T] = {
 
-    val sslCtx = maybeSslCtx.orElse {
-      if (uri.secure) Some {
+    val sslCtx = if (uri.secure) maybeSslCtx.orElse {
+      Some {
         SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build()
-      } else
-        None
-    }
+      }
+    } else
+      None
 
     val customHeaders =
       headers.foldLeft(new DefaultHttpHeaders().asInstanceOf[HttpHeaders]) {

--- a/src/main/scala/com/github/andyglow/websocket/WebsocketNettyHandshaker.scala
+++ b/src/main/scala/com/github/andyglow/websocket/WebsocketNettyHandshaker.scala
@@ -3,8 +3,8 @@ package com.github.andyglow.websocket
 import io.netty.handler.codec.http.websocketx.{WebSocketClientHandshaker13, WebSocketVersion}
 import io.netty.handler.codec.http.{FullHttpRequest, HttpHeaders}
 
-class WebsocketNettyHandshaker(uri: Uri, customHeaders: HttpHeaders) extends WebSocketClientHandshaker13(
-  uri.toURI, WebSocketVersion.V13, null, false, customHeaders, 65536) {
+class WebsocketNettyHandshaker(uri: Uri, customHeaders: HttpHeaders, subprotocol: Option[String] = None) extends WebSocketClientHandshaker13(
+  uri.toURI, WebSocketVersion.V13, subprotocol.getOrElse(null), false, customHeaders, 65536) {
 
   override def newHandshakeRequest(): FullHttpRequest = {
     val req = super.newHandshakeRequest()


### PR DESCRIPTION
We needed this functionality to be able to specify the subprotocol.  I believe the change is backward compatible.