### PR TITLE
support WebSocket frame fragmentation

### DIFF
--- a/src/main/scala/com/github/andyglow/websocket/WebsocketClient.scala
+++ b/src/main/scala/com/github/andyglow/websocket/WebsocketClient.scala
@@ -6,6 +6,7 @@ import io.netty.channel.nio.NioEventLoopGroup
 import io.netty.channel.socket.SocketChannel
 import io.netty.channel.socket.nio.NioSocketChannel
 import io.netty.handler.codec.http._
+import io.netty.handler.codec.http.websocketx.WebSocketFrameAggregator
 import io.netty.handler.logging.{LogLevel, LoggingHandler}
 import io.netty.handler.ssl.util.InsecureTrustManagerFactory
 import io.netty.handler.ssl.{SslContext, SslContextBuilder}
@@ -38,6 +39,7 @@ class WebsocketClient[T : MessageFormat] private(
           p.addLast(
             new HttpClientCodec(),
             new HttpObjectAggregator(8192),
+            new WebSocketFrameAggregator(Integer.MAX_VALUE),
             clientHandler)
         }
       })


### PR DESCRIPTION
Hi!
I'm working with a websocket server which sends messages containing a lot of data. It's doing so by using websocket's feature called `Fragmentation` according to [RFC6455 ](https://tools.ietf.org/html/rfc6455#section-5.4).

The problem is that currently only the first `WebSocketFrame` passed to `WebsocketHandler`, which leads to corrupted messages.

To support this feature, websocket client should be able to handle fragmented messages.
Netty already has an aggregator precisely for this task, so I propose just to use it.