### PR TITLE
Setting for maxFramePayloadLength

### DIFF
--- a/src/main/scala/com/github/andyglow/websocket/WebsocketClient.scala
+++ b/src/main/scala/com/github/andyglow/websocket/WebsocketClient.scala
@@ -19,12 +19,13 @@ class WebsocketClient[T : MessageFormat] private(
   sslCtx: Option[SslContext],
   customHeaders: HttpHeaders,
   handler: WebsocketHandler[T],
-  logLevel: Option[LogLevel]) {
+  logLevel: Option[LogLevel],
+  maxFramePayloadLength: Int) {
 
   private val group = new NioEventLoopGroup()
 
   private val clientHandler = new WebsocketNettytHandler(
-    new WebsocketNettyHandshaker(uri, customHeaders, subprotocol),
+    new WebsocketNettyHandshaker(uri, customHeaders, subprotocol, maxFramePayloadLength),
     handler)
 
   private val bootstrap = {
@@ -72,7 +73,8 @@ object WebsocketClient {
     headers: Map[String, String] = Map.empty,
     logLevel: Option[LogLevel] = None,
     subprotocol: Option[String] = None,
-    maybeSslCtx: Option[SslContext] = None): WebsocketClient[T] = {
+    maybeSslCtx: Option[SslContext] = None,
+    maxFramePayloadLength: Int = 65536): WebsocketClient[T] = {
 
     val sslCtx = if (uri.secure) maybeSslCtx.orElse {
       Some {
@@ -86,6 +88,6 @@ object WebsocketClient {
         case (headers, (k, v)) => headers.add(k, v)
       }
 
-    new WebsocketClient(uri, subprotocol, sslCtx, customHeaders, handler, logLevel)
+    new WebsocketClient(uri, subprotocol, sslCtx, customHeaders, handler, logLevel, maxFramePayloadLength)
   }
 }

--- a/src/main/scala/com/github/andyglow/websocket/WebsocketNettyHandshaker.scala
+++ b/src/main/scala/com/github/andyglow/websocket/WebsocketNettyHandshaker.scala
@@ -3,8 +3,8 @@ package com.github.andyglow.websocket
 import io.netty.handler.codec.http.websocketx.{WebSocketClientHandshaker13, WebSocketVersion}
 import io.netty.handler.codec.http.{FullHttpRequest, HttpHeaders}
 
-class WebsocketNettyHandshaker(uri: Uri, customHeaders: HttpHeaders, subprotocol: Option[String] = None) extends WebSocketClientHandshaker13(
-  uri.toURI, WebSocketVersion.V13, subprotocol getOrElse null, false, customHeaders, 65536) {
+class WebsocketNettyHandshaker(uri: Uri, customHeaders: HttpHeaders, subprotocol: Option[String] = None, maxFramePayloadLength: Int = 65536) extends WebSocketClientHandshaker13(
+  uri.toURI, WebSocketVersion.V13, subprotocol getOrElse null, false, customHeaders, maxFramePayloadLength) {
 
   override def newHandshakeRequest(): FullHttpRequest = {
     val req = super.newHandshakeRequest()


### PR DESCRIPTION
Setting for maxFramePayloadLength to tune maximum size of acceptable message for websocket.
In my case I need to increase this size to accept larger messages.