### PR TITLE
Error processing when websocket is functional

### DIFF
--- a/src/main/scala/com/github/andyglow/websocket/WebsocketHandler.scala
+++ b/src/main/scala/com/github/andyglow/websocket/WebsocketHandler.scala
@@ -6,6 +6,7 @@ trait WebsocketHandler[T] {
   @volatile private[websocket] var _sender: Websocket = WebsocketHandler.NoSocket
   def sender(): Websocket = _sender
   def receive: PartialFunction[T, Unit]
+  def onFailure(cause: Throwable): Unit = {}
 }
 
 object WebsocketHandler {

--- a/src/main/scala/com/github/andyglow/websocket/WebsocketNettytHandler.scala
+++ b/src/main/scala/com/github/andyglow/websocket/WebsocketNettytHandler.scala
@@ -82,7 +82,7 @@ private[websocket] class WebsocketNettytHandler[T : MessageFormat](
     ctx.close()
     atomic { implicit txn =>
       val f = handshakerFuture()
-      if (!f.isDone) f.setFailure(cause)
+      if (!f.isDone) f.setFailure(cause) else handler.onFailure(cause)
     }
   }
 


### PR DESCRIPTION
Currently there is no way how to handle failures when websocket is working and it's hard to find out what's the problem. Using the callback the client can respond to failure or at least display it in the log.